### PR TITLE
Add details on how to enable sign-off locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,14 @@
   Signed-off-by: Your Name <your@email.com>
   ```
 
+* Please enable sign-off requirement as follows:
+
+```
+./enable_signoff_requirement.sh
+```
+
+This should add hook which will check for sign-off, if it is not present it will error.
+
 * Full text of the DCO:
 
   ```


### PR DESCRIPTION
This PR provides details on how users can enable sign-off requirement locally so they can't push unsigned commits.

closes #3 