### PR TITLE
Fixes cuOpt wrapper to handle "nothing"

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -173,7 +173,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         model.affine_constraint_info = _constraint_info_dict()
 
         model.raw_optimizer_attributes = Dict{String,Any}(
-            CUOPT_TIME_LIMIT => 3600,
+            CUOPT_TIME_LIMIT => 36000,
             CUOPT_NUM_CPU_THREADS => 1,
             CUOPT_MIP_ABSOLUTE_GAP => 1e-10,
             CUOPT_MIP_RELATIVE_GAP => 1e-4,

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -471,7 +471,11 @@ function MOI.set(model::Optimizer, param::MOI.RawOptimizerAttribute, value)
     return model.raw_optimizer_attributes[param.name] = value
 end
 
-function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, time_limit::Union{Real, Nothing})
+function MOI.set(
+    model::Optimizer,
+    ::MOI.TimeLimitSec,
+    time_limit::Union{Real,Nothing},
+)
     return MOI.set(
         model,
         MOI.RawOptimizerAttribute(CUOPT_TIME_LIMIT),
@@ -486,7 +490,7 @@ end
 function MOI.set(
     model::Optimizer,
     ::MOI.NumberOfThreads,
-    number_of_threads::Union{Int, Nothing},
+    number_of_threads::Union{Int,Nothing},
 )
     return MOI.set(
         model,
@@ -498,7 +502,7 @@ end
 function MOI.set(
     model::Optimizer,
     ::MOI.AbsoluteGapTolerance,
-    absolute_gap_tolerance::Union{Float64, Nothing},
+    absolute_gap_tolerance::Union{Float64,Nothing},
 )
     return MOI.set(
         model,
@@ -510,7 +514,7 @@ end
 function MOI.set(
     model::Optimizer,
     ::MOI.RelativeGapTolerance,
-    relative_gap_tolerance::Union{Float64, Nothing},
+    relative_gap_tolerance::Union{Float64,Nothing},
 )
     return MOI.set(
         model,

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -996,7 +996,7 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
 
     # Set all raw optimizer attributes
     for (name, value) in dest.raw_optimizer_attributes
-        if value != Nothing
+        if value !== nothing
             ret = cuOptSetParameter(dest.cuopt_settings, name, string(value))
             _check_ret(ret, "cuOptSetParameter($name, $value)")
         end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -172,7 +172,12 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         model.variable_info = _variable_info_dict()
         model.affine_constraint_info = _constraint_info_dict()
 
-        model.raw_optimizer_attributes = Dict{String,Any}()
+        model.raw_optimizer_attributes = Dict{String,Any}(
+            CUOPT_TIME_LIMIT => 3600,
+            CUOPT_NUM_CPU_THREADS => 1,
+            CUOPT_MIP_ABSOLUTE_GAP => 1e-10,
+            CUOPT_MIP_RELATIVE_GAP => 1e-4,
+        )
 
         model.objective_sense = nothing
 


### PR DESCRIPTION
cuOpt wrapper was not able to handle "nothing"/None in a proper way, which resulted in wrapper once set with actual value, can't be set to "nothing"/None.  This PR adds that functionality for the settings.