### PR TITLE
Update for cuOpt v26.04

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use cuOpt.jl, you must first separately install cuOpt.
 
 **Installing cuOpt requires Linux.**
 
-Note: This version of cuOpt.jl supports the Nvidia cuOpt 26.02 releases.
+Note: This version of cuOpt.jl supports the Nvidia cuOpt 26.04 releases.
 
 Please refer to the [NVIDIA cuOpt documentation](https://docs.nvidia.com/cuopt/user-guide/latest/cuopt-c/quick-start.html#installation) for installation instructions.
 
@@ -48,7 +48,7 @@ Pkg.add("cuOpt")
 
 To install cuOpt on [Google Colab](https://colab.research.google.com), do:
 ```julia
-julia> cmd = run(`pip install --extra-index-url=https://pypi.nvidia.com libcuopt-cu12==26.2.\* nvidia-cuda-runtime-cu12==12.8.\*`);
+julia> cmd = run(`pip install --extra-index-url=https://pypi.nvidia.com libcuopt-cu12==26.4.\* nvidia-cuda-runtime-cu12==12.8.\*`);
 
 julia> push!(Base.DL_LOAD_PATH, "/usr/local/lib/python3.12/dist-packages/libcuopt/lib64")
 ```

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gen/gen.jl
+++ b/gen/gen.jl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gen/generate.toml
+++ b/gen/generate.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -285,8 +285,10 @@ const _TerminationStatusMap = Dict(
         (MOI.OTHER_ERROR, "cuOptModelStatusConcurrent"),
     CUOPT_TERMINATION_STATUS_WORK_LIMIT =>
         (MOI.OTHER_LIMIT, "cuOptModelStatusWorkLimit"),
-    CUOPT_TERMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE =>
-        (MOI.INFEASIBLE_OR_UNBOUNDED, "cuOptModelStatusUnboundedOrInfeasible"),
+    CUOPT_TERMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE => (
+        MOI.INFEASIBLE_OR_UNBOUNDED,
+        "cuOptModelStatusUnboundedOrInfeasible",
+    ),
 )
 
 function MOI.get(model::Optimizer, ::MOI.TerminationStatus)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -179,7 +179,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         model.primal_solution = Float64[]
         model.dual_solution = Float64[]
         model.obj_value = 0.0
-        model.termination_status = CUOPT_TERIMINATION_STATUS_NO_TERMINATION
+        model.termination_status = CUOPT_TERMINATION_STATUS_NO_TERMINATION
         return model
     end
 end
@@ -263,26 +263,30 @@ function MOI.get(model::Optimizer, ::MOI.NumberOfVariables)
 end
 
 const _TerminationStatusMap = Dict(
-    CUOPT_TERIMINATION_STATUS_NO_TERMINATION =>
+    CUOPT_TERMINATION_STATUS_NO_TERMINATION =>
         (MOI.OPTIMIZE_NOT_CALLED, "cuOptModelStatusNotset"),
-    CUOPT_TERIMINATION_STATUS_OPTIMAL =>
+    CUOPT_TERMINATION_STATUS_OPTIMAL =>
         (MOI.OPTIMAL, "cuOptModelStatusOptimal"),
-    CUOPT_TERIMINATION_STATUS_INFEASIBLE =>
+    CUOPT_TERMINATION_STATUS_INFEASIBLE =>
         (MOI.INFEASIBLE, "cuOptModelStatusInfeasible"),
-    CUOPT_TERIMINATION_STATUS_UNBOUNDED =>
+    CUOPT_TERMINATION_STATUS_UNBOUNDED =>
         (MOI.DUAL_INFEASIBLE, "cuOptModelStatusUnbounded"),
-    CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT =>
+    CUOPT_TERMINATION_STATUS_ITERATION_LIMIT =>
         (MOI.ITERATION_LIMIT, "cuOptModelStatusIterationLimit"),
-    CUOPT_TERIMINATION_STATUS_TIME_LIMIT =>
+    CUOPT_TERMINATION_STATUS_TIME_LIMIT =>
         (MOI.TIME_LIMIT, "cuOptModelStatusTimeLimit"),
-    CUOPT_TERIMINATION_STATUS_NUMERICAL_ERROR =>
+    CUOPT_TERMINATION_STATUS_NUMERICAL_ERROR =>
         (MOI.NUMERICAL_ERROR, "cuOptModelStatusNumericalError"),
-    CUOPT_TERIMINATION_STATUS_PRIMAL_FEASIBLE =>
+    CUOPT_TERMINATION_STATUS_PRIMAL_FEASIBLE =>
         (MOI.OTHER_LIMIT, "cuOptModelStatusPrimalFeasible"),
-    CUOPT_TERIMINATION_STATUS_CONCURRENT_LIMIT =>
-        (MOI.OTHER_ERROR, "cuOptModelStatusConcurrent"),
-    CUOPT_TERIMINATION_STATUS_FEASIBLE_FOUND =>
+    CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND =>
         (MOI.OTHER_LIMIT, "cuOptModelStatusFeasible"),
+    CUOPT_TERMINATION_STATUS_CONCURRENT_LIMIT =>
+        (MOI.OTHER_ERROR, "cuOptModelStatusConcurrent"),
+    CUOPT_TERMINATION_STATUS_WORK_LIMIT =>
+        (MOI.OTHER_LIMIT, "cuOptModelStatusWorkLimit"),
+    CUOPT_TERMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE =>
+        (MOI.INFEASIBLE_OR_UNBOUNDED, "cuOptModelStatusUnboundedOrInfeasible"),
 )
 
 function MOI.get(model::Optimizer, ::MOI.TerminationStatus)
@@ -419,10 +423,10 @@ end
 
 function MOI.get(model::Optimizer, ::MOI.ResultCount)
     status = model.termination_status
-    if status == CUOPT_TERIMINATION_STATUS_OPTIMAL ||
-       status == CUOPT_TERIMINATION_STATUS_PRIMAL_FEASIBLE ||
-       status == CUOPT_TERIMINATION_STATUS_FEASIBLE_FOUND ||
-       status == CUOPT_TERIMINATION_STATUS_UNBOUNDED
+    if status == CUOPT_TERMINATION_STATUS_OPTIMAL ||
+       status == CUOPT_TERMINATION_STATUS_PRIMAL_FEASIBLE ||
+       status == CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND ||
+       status == CUOPT_TERMINATION_STATUS_UNBOUNDED
         return 1
     end
     return 0
@@ -432,11 +436,11 @@ function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
     status = model.termination_status
     if attr.result_index != 1
         return MOI.NO_SOLUTION
-    elseif status == CUOPT_TERIMINATION_STATUS_OPTIMAL ||
-           status == CUOPT_TERIMINATION_STATUS_PRIMAL_FEASIBLE ||
-           status == CUOPT_TERIMINATION_STATUS_FEASIBLE_FOUND
+    elseif status == CUOPT_TERMINATION_STATUS_OPTIMAL ||
+           status == CUOPT_TERMINATION_STATUS_PRIMAL_FEASIBLE ||
+           status == CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND
         return MOI.FEASIBLE_POINT
-    elseif status == CUOPT_TERIMINATION_STATUS_INFEASIBLE
+    elseif status == CUOPT_TERMINATION_STATUS_INFEASIBLE
         return MOI.INFEASIBLE_POINT
     end
     return MOI.NO_SOLUTION
@@ -446,7 +450,7 @@ function MOI.get(model::Optimizer, attr::MOI.DualStatus)
     status = model.termination_status
     if attr.result_index != 1
         return MOI.NO_SOLUTION
-    elseif status == CUOPT_TERIMINATION_STATUS_OPTIMAL
+    elseif status == CUOPT_TERMINATION_STATUS_OPTIMAL
         return MOI.FEASIBLE_POINT
     end
     return MOI.NO_SOLUTION
@@ -560,7 +564,7 @@ function MOI.empty!(model::Optimizer)
     model.primal_solution = Float64[]
     model.dual_solution = Float64[]
     model.obj_value = NaN
-    model.termination_status = CUOPT_TERIMINATION_STATUS_NO_TERMINATION
+    model.termination_status = CUOPT_TERMINATION_STATUS_NO_TERMINATION
 
     if model.cuopt_problem != C_NULL
         a = Ref(model.cuopt_problem)

--- a/src/cuOpt.jl
+++ b/src/cuOpt.jl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +46,7 @@ function __init__()
         error("Failed to get cuOpt library version (status code: $status)")
     end
     version = VersionNumber(major[], minor[], patch[])
-    min, max = v"26.02", v"26.03"
+    min, max = v"26.04", v"26.05"
     if !(min <= version < max)
         error(
             "Incompatible cuOpt library version. Got $version, but supported versions are [$min, $max)",

--- a/src/gen/libcuopt.jl
+++ b/src/gen/libcuopt.jl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1016,6 +1016,10 @@ const CUOPT_MIP_MIXED_INTEGER_GOMORY_CUTS = "mip_mixed_integer_gomory_cuts"
 
 const CUOPT_MIP_KNAPSACK_CUTS = "mip_knapsack_cuts"
 
+const CUOPT_MIP_IMPLIED_BOUND_CUTS = "mip_implied_bound_cuts"
+
+const CUOPT_MIP_CLIQUE_CUTS = "mip_clique_cuts"
+
 const CUOPT_MIP_STRONG_CHVATAL_GOMORY_CUTS = "mip_strong_chvatal_gomory_cuts"
 
 const CUOPT_MIP_REDUCED_COST_STRENGTHENING = "mip_reduced_cost_strengthening"
@@ -1026,6 +1030,10 @@ const CUOPT_MIP_CUT_MIN_ORTHOGONALITY = "mip_cut_min_orthogonality"
 
 const CUOPT_MIP_BATCH_PDLP_STRONG_BRANCHING = "mip_batch_pdlp_strong_branching"
 
+const CUOPT_MIP_BATCH_PDLP_RELIABILITY_BRANCHING = "mip_batch_pdlp_reliability_branching"
+
+const CUOPT_MIP_STRONG_BRANCHING_SIMPLEX_ITERATION_LIMIT = "mip_strong_branching_simplex_iteration_limit"
+
 const CUOPT_SOLUTION_FILE = "solution_file"
 
 const CUOPT_NUM_CPU_THREADS = "num_cpu_threads"
@@ -1034,31 +1042,73 @@ const CUOPT_NUM_GPUS = "num_gpus"
 
 const CUOPT_USER_PROBLEM_FILE = "user_problem_file"
 
+const CUOPT_PRESOLVE_FILE = "presolve_file"
+
 const CUOPT_RANDOM_SEED = "random_seed"
+
+const CUOPT_PDLP_PRECISION = "pdlp_precision"
+
+const CUOPT_MIP_HYPER_HEURISTIC_POPULATION_SIZE = "mip_hyper_heuristic_population_size"
+
+const CUOPT_MIP_HYPER_HEURISTIC_NUM_CPUFJ_THREADS = "mip_hyper_heuristic_num_cpufj_threads"
+
+const CUOPT_MIP_HYPER_HEURISTIC_PRESOLVE_TIME_RATIO = "mip_hyper_heuristic_presolve_time_ratio"
+
+const CUOPT_MIP_HYPER_HEURISTIC_PRESOLVE_MAX_TIME = "mip_hyper_heuristic_presolve_max_time"
+
+const CUOPT_MIP_HYPER_HEURISTIC_ROOT_LP_TIME_RATIO = "mip_hyper_heuristic_root_lp_time_ratio"
+
+const CUOPT_MIP_HYPER_HEURISTIC_ROOT_LP_MAX_TIME = "mip_hyper_heuristic_root_lp_max_time"
+
+const CUOPT_MIP_HYPER_HEURISTIC_RINS_TIME_LIMIT = "mip_hyper_heuristic_rins_time_limit"
+
+const CUOPT_MIP_HYPER_HEURISTIC_RINS_MAX_TIME_LIMIT = "mip_hyper_heuristic_rins_max_time_limit"
+
+const CUOPT_MIP_HYPER_HEURISTIC_RINS_FIX_RATE = "mip_hyper_heuristic_rins_fix_rate"
+
+const CUOPT_MIP_HYPER_HEURISTIC_STAGNATION_TRIGGER = "mip_hyper_heuristic_stagnation_trigger"
+
+const CUOPT_MIP_HYPER_HEURISTIC_MAX_ITERS_WITHOUT_IMPROVEMENT = "mip_hyper_heuristic_max_iterations_without_improvement"
+
+const CUOPT_MIP_HYPER_HEURISTIC_INITIAL_INFEASIBILITY_WEIGHT = "mip_hyper_heuristic_initial_infeasibility_weight"
+
+const CUOPT_MIP_HYPER_HEURISTIC_N_OF_MINIMUMS_FOR_EXIT = "mip_hyper_heuristic_n_of_minimums_for_exit"
+
+const CUOPT_MIP_HYPER_HEURISTIC_ENABLED_RECOMBINERS = "mip_hyper_heuristic_enabled_recombiners"
+
+const CUOPT_MIP_HYPER_HEURISTIC_CYCLE_DETECTION_LENGTH = "mip_hyper_heuristic_cycle_detection_length"
+
+const CUOPT_MIP_HYPER_HEURISTIC_RELAXED_LP_TIME_LIMIT = "mip_hyper_heuristic_relaxed_lp_time_limit"
+
+const CUOPT_MIP_HYPER_HEURISTIC_RELATED_VARS_TIME_LIMIT = "mip_hyper_heuristic_related_vars_time_limit"
 
 const CUOPT_MODE_OPPORTUNISTIC = 0
 
 const CUOPT_MODE_DETERMINISTIC = 1
 
-const CUOPT_TERIMINATION_STATUS_NO_TERMINATION = 0
+const CUOPT_TERMINATION_STATUS_NO_TERMINATION = 0
 
-const CUOPT_TERIMINATION_STATUS_OPTIMAL = 1
+const CUOPT_TERMINATION_STATUS_OPTIMAL = 1
 
-const CUOPT_TERIMINATION_STATUS_INFEASIBLE = 2
+const CUOPT_TERMINATION_STATUS_INFEASIBLE = 2
 
-const CUOPT_TERIMINATION_STATUS_UNBOUNDED = 3
+const CUOPT_TERMINATION_STATUS_UNBOUNDED = 3
 
-const CUOPT_TERIMINATION_STATUS_ITERATION_LIMIT = 4
+const CUOPT_TERMINATION_STATUS_ITERATION_LIMIT = 4
 
-const CUOPT_TERIMINATION_STATUS_TIME_LIMIT = 5
+const CUOPT_TERMINATION_STATUS_TIME_LIMIT = 5
 
-const CUOPT_TERIMINATION_STATUS_NUMERICAL_ERROR = 6
+const CUOPT_TERMINATION_STATUS_NUMERICAL_ERROR = 6
 
-const CUOPT_TERIMINATION_STATUS_PRIMAL_FEASIBLE = 7
+const CUOPT_TERMINATION_STATUS_PRIMAL_FEASIBLE = 7
 
-const CUOPT_TERIMINATION_STATUS_FEASIBLE_FOUND = 8
+const CUOPT_TERMINATION_STATUS_FEASIBLE_FOUND = 8
 
-const CUOPT_TERIMINATION_STATUS_CONCURRENT_LIMIT = 9
+const CUOPT_TERMINATION_STATUS_CONCURRENT_LIMIT = 9
+
+const CUOPT_TERMINATION_STATUS_WORK_LIMIT = 10
+
+const CUOPT_TERMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE = 11
 
 const CUOPT_TERIMINATION_STATUS_WORK_LIMIT = 10
 
@@ -1096,6 +1146,16 @@ const CUOPT_METHOD_DUAL_SIMPLEX = 2
 
 const CUOPT_METHOD_BARRIER = 3
 
+const CUOPT_METHOD_UNSET = 4
+
+const CUOPT_PDLP_DEFAULT_PRECISION = -1
+
+const CUOPT_PDLP_SINGLE_PRECISION = 0
+
+const CUOPT_PDLP_DOUBLE_PRECISION = 1
+
+const CUOPT_PDLP_MIXED_PRECISION = 2
+
 const CUOPT_FILE_FORMAT_MPS = 0
 
 const CUOPT_SUCCESS = 0
@@ -1119,3 +1179,9 @@ const CUOPT_PRESOLVE_OFF = 0
 const CUOPT_PRESOLVE_PAPILO = 1
 
 const CUOPT_PRESOLVE_PSLP = 2
+
+const CUOPT_MIP_SCALING_OFF = 0
+
+const CUOPT_MIP_SCALING_ON = 1
+
+const CUOPT_MIP_SCALING_NO_OBJECTIVE = 2

--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,7 +99,7 @@ function test_Direct_C_call()
     termination_status = Ref{Cint}(0)
     ret = cuOpt.cuOptGetTerminationStatus(solution, termination_status)
     @test ret == 0
-    @test termination_status[] == cuOpt.CUOPT_TERIMINATION_STATUS_OPTIMAL
+    @test termination_status[] == cuOpt.CUOPT_TERMINATION_STATUS_OPTIMAL
 
     cuOpt.cuOptDestroySolution(solution_ref)
     cuOpt.cuOptDestroySolverSettings(settings_ref)
@@ -163,7 +163,7 @@ function test_QuadraticProblem_C_call()
     termination_status = Ref{Cint}(0)
     ret = cuOpt.cuOptGetTerminationStatus(solution, termination_status)
     @test ret == 0
-    @test termination_status[] == cuOpt.CUOPT_TERIMINATION_STATUS_OPTIMAL
+    @test termination_status[] == cuOpt.CUOPT_TERMINATION_STATUS_OPTIMAL
 
     obj_value = Ref{Cdouble}(0.0)
     ret = cuOpt.cuOptGetObjectiveValue(solution, obj_value)
@@ -232,7 +232,7 @@ function test_QuadraticRangedProblem_C_call()
     termination_status = Ref{Cint}(0)
     ret = cuOpt.cuOptGetTerminationStatus(solution, termination_status)
     @test ret == 0
-    @test termination_status[] == cuOpt.CUOPT_TERIMINATION_STATUS_OPTIMAL
+    @test termination_status[] == cuOpt.CUOPT_TERMINATION_STATUS_OPTIMAL
 
     obj_value = Ref{Cdouble}(0.0)
     ret = cuOpt.cuOptGetObjectiveValue(solution, obj_value)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -55,12 +55,7 @@ function test_runtests_cache_optimizer()
                 MOI.ConstraintBasisStatus,
             ],
         );
-        exclude = [
-            # upstream bug https://github.com/NVIDIA/cuopt/issues/923
-            "test_solve_TerminationStatus_DUAL_INFEASIBLE",
-            "test_linear_DUAL_INFEASIBLE",
-            "test_linear_DUAL_INFEASIBLE_2",
-        ],
+        exclude = [],
     )
     return
 end
@@ -73,9 +68,7 @@ function test_air05()
     MOI.set(model, MOI.RawOptimizerAttribute(cuOpt.CUOPT_TIME_LIMIT), 60.0)
     MOI.copy_to(model, src)
     MOI.optimize!(model)
-    # upstream bug: https://github.com/NVIDIA/cuopt/issues/855, should be fixed in 26.04
-    # @test_broken to be fixed when upgrading to cuopt 26.04
-    @test_broken MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
     @test isapprox(MOI.get(model, MOI.ObjectiveValue()), 26374.0; rtol = 1e-4)
     return
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Also update license headers.

Tested locally. We can re-enable some previously broken and excluded tests.