### PR TITLE
Update to cuOpt 26.06 + new features

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,19 +16,17 @@
 
 name = "cuOpt"
 uuid = "29a73d17-8276-40b7-9ffb-d89e58023643"
-authors = ["Rajesh Gandham <rgandham@nvidia.com>", "Ramakrishna Prabhu <ramakrishnap@nvidia.com>"]
-version = "0.2.1"
+authors = ["Rajesh Gandham <rgandham@nvidia.com>", "Ramakrishna Prabhu <ramakrishnap@nvidia.com>", "Miles Lubin <mlubin@nvidia.com>"]
+version = "0.3.0"
 
 [deps]
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 MathOptInterface = "1.34"
 PrecompileTools = "1"
-SparseArrays = "1"
 Test = "1.6"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To use cuOpt.jl, you must first separately install cuOpt.
 
 **Installing cuOpt requires Linux.**
 
-Note: This version of cuOpt.jl supports the Nvidia cuOpt 26.04 release.
+Note: This version of cuOpt.jl supports the Nvidia cuOpt 26.06 release.
 
 Please refer to the [NVIDIA cuOpt documentation](https://docs.nvidia.com/cuopt/user-guide/latest/cuopt-c/quick-start.html#installation) for installation instructions.
 
@@ -48,7 +48,7 @@ Pkg.add("cuOpt")
 
 To install cuOpt on [Google Colab](https://colab.research.google.com), do:
 ```julia
-julia> cmd = run(`pip install --extra-index-url=https://pypi.nvidia.com libcuopt-cu12==26.4.\* nvidia-cuda-runtime-cu12==12.8.\*`);
+julia> cmd = run(`pip install --extra-index-url=https://pypi.nvidia.com libcuopt-cu12==26.6.\* nvidia-cuda-runtime-cu12==12.8.\*`);
 
 julia> push!(Base.DL_LOAD_PATH, "/usr/local/lib/python3.12/dist-packages/libcuopt/lib64")
 ```

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -18,8 +18,6 @@
 # The HiGHS wrapper is released under an MIT license, a copy of which can be
 # found in `/thirdparty/THIRD_PARTY_LICENSES` or at https://opensource.org/licenses/MIT.
 
-import SparseArrays
-
 import MathOptInterface as MOI
 const CleverDicts = MOI.Utilities.CleverDicts
 
@@ -45,7 +43,13 @@ _bounds(s::MOI.EqualTo{Float64}) = s.value, s.value
     _BOUND_EQUAL_TO,
 )
 
-@enum(_TypeEnum, _TYPE_CONTINUOUS, _TYPE_INTEGER, _TYPE_BINARY,)
+@enum(
+    _TypeEnum,
+    _TYPE_CONTINUOUS,
+    _TYPE_INTEGER,
+    _TYPE_BINARY,
+    _TYPE_SEMICONTINUOUS,
+)
 
 """
     _VariableInfo
@@ -124,6 +128,29 @@ function _constraint_info_dict()
 end
 
 """
+    _QuadraticConstraintInfo
+
+A struct to store information about a quadratic constraint. cuOpt stores
+quadratic constraints internally; this struct only keeps the MOI-facing
+metadata so that the wrapper can answer queries after `copy_to`.
+"""
+mutable struct _QuadraticConstraintInfo
+    name::String
+    # CUOPT_LESS_THAN or CUOPT_GREATER_THAN
+    sense::Cchar
+    # The right-hand side of the original MOI set (before the function constant
+    # is folded into the cuOpt rhs).
+    set_rhs::Float64
+end
+
+function _quadratic_constraint_info_dict()
+    return CleverDicts.CleverDict{_ConstraintKey,_QuadraticConstraintInfo}(
+        c -> c.value,
+        i -> _ConstraintKey(i),
+    )
+end
+
+"""
     _set(c::_ConstraintInfo)
 
 Return the set associated with a constraint.
@@ -153,6 +180,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
 
     variable_info::typeof(_variable_info_dict())
     affine_constraint_info::typeof(_constraint_info_dict())
+    quadratic_constraint_info::typeof(_quadratic_constraint_info_dict())
 
     raw_optimizer_attributes::Dict{String,Any}
     objective_sense::Union{Nothing,MOI.OptimizationSense}
@@ -173,6 +201,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
 
         model.variable_info = _variable_info_dict()
         model.affine_constraint_info = _constraint_info_dict()
+        model.quadratic_constraint_info = _quadratic_constraint_info_dict()
 
         model.raw_optimizer_attributes = Dict{String,Any}()
 
@@ -191,6 +220,7 @@ MOI.supports_incremental_interface(::Optimizer) = false
 function MOI.is_empty(model::Optimizer)
     return length(model.variable_info) == 0 &&
            length(model.affine_constraint_info) == 0 &&
+           length(model.quadratic_constraint_info) == 0 &&
            model.objective_sense == nothing &&
            model.name == ""
 end
@@ -246,7 +276,10 @@ function MOI.get(model::Optimizer, ::MOI.TimeLimitSec)
 end
 #MOI.get(model::Optimizer, ::MOI.ObjectiveLimit) = model.objective_limit
 #MOI.get(model::Optimizer, ::MOI.SolutionLimit) = model.solution_limit
-#MOI.get(model::Optimizer, ::MOI.NodeLimit) = model.node_limit
+
+function MOI.get(model::Optimizer, ::MOI.NodeLimit)
+    return MOI.get(model, MOI.RawOptimizerAttribute(CUOPT_NODE_LIMIT))
+end
 
 function MOI.get(model::Optimizer, ::MOI.NumberOfThreads)
     return MOI.get(model, MOI.RawOptimizerAttribute(CUOPT_NUM_CPU_THREADS))
@@ -493,7 +526,18 @@ end
 
 #MOI.set(model::Optimizer, ::MOI.ObjectiveLimit, objective_limit::Float64) = model.objective_limit = objective_limit
 #MOI.set(model::Optimizer, ::MOI.SolutionLimit, solution_limit::Int) = model.solution_limit = solution_limit
-#MOI.set(model::Optimizer, ::MOI.NodeLimit, node_limit::Int) = model.node_limit = node_limit
+
+function MOI.set(
+    model::Optimizer,
+    ::MOI.NodeLimit,
+    node_limit::Union{Integer,Nothing},
+)
+    return MOI.set(
+        model,
+        MOI.RawOptimizerAttribute(CUOPT_NODE_LIMIT),
+        node_limit,
+    )
+end
 
 function MOI.set(
     model::Optimizer,
@@ -550,7 +594,7 @@ MOI.supports(::Optimizer, ::MOI.Silent) = true
 MOI.supports(::Optimizer, ::MOI.TimeLimitSec) = true
 MOI.supports(::Optimizer, ::MOI.ObjectiveLimit) = false
 MOI.supports(::Optimizer, ::MOI.SolutionLimit) = false
-MOI.supports(::Optimizer, ::MOI.NodeLimit) = false
+MOI.supports(::Optimizer, ::MOI.NodeLimit) = true
 MOI.supports(::Optimizer, ::MOI.RawOptimizerAttribute) = true
 MOI.supports(::Optimizer, ::MOI.NumberOfThreads) = true
 MOI.supports(::Optimizer, ::MOI.AbsoluteGapTolerance) = true
@@ -564,6 +608,7 @@ function MOI.empty!(model::Optimizer)
     # attribute silent should not be cleared
     model.variable_info = _variable_info_dict()
     model.affine_constraint_info = _constraint_info_dict()
+    model.quadratic_constraint_info = _quadratic_constraint_info_dict()
     model.objective_sense = nothing
     model.primal_solution = Float64[]
     model.dual_solution = Float64[]
@@ -609,12 +654,21 @@ function MOI.supports_constraint(
     return true
 end
 
-# does not support semicontinuous and semiinteger constraints on variables
+# supports semicontinuous variables via cuOpt's CUOPT_SEMI_CONTINUOUS variable
+# type. Semiinteger has no cuOpt counterpart and remains unsupported.
 function MOI.supports_constraint(
     ::Optimizer,
     ::Type{MOI.VariableIndex},
-    ::Type{S},
-) where {S<:Union{MOI.Semicontinuous{Float64},MOI.Semiinteger}}
+    ::Type{MOI.Semicontinuous{Float64}},
+)
+    return true
+end
+
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.VariableIndex},
+    ::Type{<:MOI.Semiinteger},
+)
     return false
 end
 
@@ -625,6 +679,29 @@ function MOI.supports_constraint(
     ::Type{<:_SCALAR_SETS},
 )
     return true
+end
+
+# supports L and G quadratic constraints (cuOpt's cuOptAddQuadraticConstraint
+# only accepts CUOPT_LESS_THAN or CUOPT_GREATER_THAN — EqualTo and Interval are
+# not supported).
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.ScalarQuadraticFunction{Float64}},
+    ::Type{<:Union{MOI.LessThan{Float64},MOI.GreaterThan{Float64}}},
+)
+    return true
+end
+
+# SecondOrderCone is lowered to ScalarQuadraticFunction via MOI's
+# SOCtoNonConvexQuadBridge: `Σxᵢ² − t² ≤ 0` plus an explicit `t ≥ 0` row.
+# cuOpt's barrier detects the SOC structure in this form ("Second-order cones :
+# N" in the solve log).
+#
+# TODO: also add RSOCtoNonConvexQuadBridge once
+# https://github.com/NVIDIA/cuopt/issues/1435 is fixed. For now RSOC flows
+# through MOI's default RSOCtoSOCBridge, chaining into SOCtoNonConvexQuadBridge.
+function MOI.get(::Optimizer, ::MOI.Bridges.ListOfNonstandardBridges{Float64})
+    return Type[MOI.Bridges.Constraint.SOCtoNonConvexQuadBridge{Float64}]
 end
 
 function MOI.supports(
@@ -904,6 +981,75 @@ function _extract_row_data(
     return
 end
 
+function _add_quadratic_constraints(
+    dest::Optimizer,
+    src::MOI.ModelLike,
+    mapping,
+    problem::cuOptOptimizationProblem,
+    ::Type{S},
+) where {S<:Union{MOI.LessThan{Float64},MOI.GreaterThan{Float64}}}
+    F = MOI.ScalarQuadraticFunction{Float64}
+    sense_char =
+        S == MOI.LessThan{Float64} ? CUOPT_LESS_THAN : CUOPT_GREATER_THAN
+    for c_index in _constraints(src, F, S)
+        f = MOI.get(src, MOI.ConstraintFunction(), c_index)
+        set = MOI.get(src, MOI.ConstraintSet(), c_index)
+
+        # Q in COO. Same convention as the objective: MOI's symmetric Q halved
+        # on the diagonal; off-diagonals carry the MOI coefficient as-is and
+        # duplicate (row, col) pairs are summed by cuOpt.
+        nq = length(f.quadratic_terms)
+        q_rows = Vector{Int32}(undef, nq)
+        q_cols = Vector{Int32}(undef, nq)
+        q_values = Vector{Float64}(undef, nq)
+        for (k, qterm) in enumerate(f.quadratic_terms)
+            i = mapping[qterm.variable_1].value
+            j = mapping[qterm.variable_2].value
+            v = qterm.coefficient
+            if i == j
+                v /= 2
+            end
+            q_rows[k] = Int32(i - 1)
+            q_cols[k] = Int32(j - 1)
+            q_values[k] = v
+        end
+
+        nl = length(f.affine_terms)
+        l_index = Vector{Int32}(undef, nl)
+        l_coef = Vector{Float64}(undef, nl)
+        for (k, aterm) in enumerate(f.affine_terms)
+            l_index[k] = Int32(mapping[aterm.variable].value - 1)
+            l_coef[k] = aterm.coefficient
+        end
+
+        set_rhs = S == MOI.LessThan{Float64} ? set.upper : set.lower
+        ret = cuOptAddQuadraticConstraint(
+            problem,
+            Int32(nq),
+            q_rows,
+            q_cols,
+            q_values,
+            Int32(nl),
+            l_index,
+            l_coef,
+            sense_char,
+            set_rhs - f.constant,
+        )
+        _check_ret(ret, "cuOptAddQuadraticConstraint")
+
+        key = CleverDicts.add_item(
+            dest.quadratic_constraint_info,
+            _QuadraticConstraintInfo("", sense_char, set_rhs),
+        )
+        if MOI.supports(src, MOI.ConstraintName(), MOI.ConstraintIndex{F,S})
+            dest.quadratic_constraint_info[key].name =
+                MOI.get(src, MOI.ConstraintName(), c_index)
+        end
+        mapping[c_index] = MOI.ConstraintIndex{F,S}(key.value)
+    end
+    return
+end
+
 function _get_objective_data(
     dest::Optimizer,
     src::MOI.ModelLike,
@@ -922,16 +1068,16 @@ function _get_objective_data(
 
     objective_offset,
     objective_coefficients_linear,
-    qobj_row_offsets,
-    qobj_col_indices,
-    qobj_matrix_values = _get_objective_data(f_obj, mapping, numcol)
+    qobj_rows,
+    qobj_cols,
+    qobj_values = _get_objective_data(f_obj, mapping, numcol)
 
     return objective_sense,
     objective_offset,
     objective_coefficients_linear,
-    qobj_row_offsets,
-    qobj_col_indices,
-    qobj_matrix_values
+    qobj_rows,
+    qobj_cols,
+    qobj_values
 end
 
 function _get_objective_data(
@@ -949,7 +1095,7 @@ function _get_objective_data(
 
     return objective_offset,
     objective_coefficients_linear,
-    Int32[0],
+    Int32[],
     Int32[],
     Float64[]
 end
@@ -967,45 +1113,33 @@ function _get_objective_data(
         objective_coefficients_linear[i] += term.coefficient
     end
 
-    # Extract quadratic objective
-    Qtrows = Int32[]
-    Qtcols = Int32[]
-    Qtvals = Float64[]
-    sizehint!(Qtrows, length(f_obj.quadratic_terms))
-    sizehint!(Qtcols, length(f_obj.quadratic_terms))
-    sizehint!(Qtvals, length(f_obj.quadratic_terms))
-    for qterm in f_obj.quadratic_terms
+    # MOI stores quadratic functions as `¹/₂ xᵀQx + aᵀx + b`, with `Q` symmetric...
+    # (https://jump.dev/MathOptInterface.jl/stable/reference/standard_form/#MathOptInterface.ScalarQuadraticFunction)
+    # ... whereas cuOpt expects a QP objective of the form `xᵀQx + aᵀx + b`,
+    #     where `Q` need not be symmetric
+    # --> diagonal coefficients are scaled by ¹/₂; off-diagonal terms keep their
+    #     MOI coefficient and are emitted once (cuOpt sums duplicate (row, col)).
+    nterms = length(f_obj.quadratic_terms)
+    qobj_rows = Vector{Int32}(undef, nterms)
+    qobj_cols = Vector{Int32}(undef, nterms)
+    qobj_values = Vector{Float64}(undef, nterms)
+    for (k, qterm) in enumerate(f_obj.quadratic_terms)
         i = mapping[qterm.variable_1].value
         j = mapping[qterm.variable_2].value
         v = qterm.coefficient
-        # MOI stores quadratic functions as `¹/₂ xᵀQx + aᵀx + b`, with `Q` symmetric...
-        # (https://jump.dev/MathOptInterface.jl/stable/reference/standard_form/#MathOptInterface.ScalarQuadraticFunction)
-        # ... whereas cuOpt expects a QP objective of the form `¹xᵀQx + aᵀx + b`,
-        #     where `Q` need not be symmetric
-        # --> we need to scale diagonal coeffs. by ¹/₂ to match cuOpt convention
         if i == j
             v /= 2
         end
-
-        # We are building a COO of Qᵀ --> swap i and j
-        push!(Qtrows, j)
-        push!(Qtcols, i)
-        push!(Qtvals, v)
+        qobj_rows[k] = Int32(i - 1)
+        qobj_cols[k] = Int32(j - 1)
+        qobj_values[k] = v
     end
-    # CSC of Qᵀ is CSR of Q
-    Qt = SparseArrays.sparse(Qtrows, Qtcols, Qtvals, numcol, numcol)
-    qobj_matrix_values = Qt.nzval
-    qobj_row_offsets = Qt.colptr
-    qobj_col_indices = Qt.rowval
-    # Revert to 0-based indexing
-    qobj_row_offsets .-= Int32(1)
-    qobj_col_indices .-= Int32(1)
 
     return objective_offset,
     objective_coefficients_linear,
-    qobj_row_offsets,
-    qobj_col_indices,
-    qobj_matrix_values
+    qobj_rows,
+    qobj_cols,
+    qobj_values
 end
 
 function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
@@ -1061,62 +1195,66 @@ function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
         mapping[ci] = typeof(ci)(new_x.value)
         has_integrality = true
     end
+    for ci in _constraints(src, MOI.VariableIndex, MOI.Semicontinuous{Float64})
+        info = _info(dest, ci)
+        info.type = _TYPE_SEMICONTINUOUS
+        var_type[info.column+1] = CUOPT_SEMI_CONTINUOUS
+        set = MOI.get(src, MOI.ConstraintSet(), ci)
+        # MOI: x ∈ {0} ∪ [set.lower, set.upper]. Pass [l, u] verbatim and rely
+        # on cuOpt's CUOPT_SEMI_CONTINUOUS type tag to OR with {0}.
+        collower[info.column+1] = max(collower[info.column+1], set.lower)
+        colupper[info.column+1] = min(colupper[info.column+1], set.upper)
+        new_x = mapping[MOI.VariableIndex(ci.value)]
+        mapping[ci] = typeof(ci)(new_x.value)
+        has_integrality = true
+    end
 
     objective_sense,
     objective_offset,
     objective_coefficients,
-    qobj_row_offsets,
-    qobj_col_indices,
-    qobj_matrix_values = _get_objective_data(dest, src, mapping, numcol)
+    qobj_rows,
+    qobj_cols,
+    qobj_values = _get_objective_data(dest, src, mapping, numcol)
 
-    # Is this a QP or an LP?
-    has_quadratic_objective = length(qobj_matrix_values) > 0
+    has_quadratic_objective = !isempty(qobj_values)
     if has_quadratic_objective && has_integrality
         error(
-            "cuOpt does not support models with quadratic objectives _and_ integer variables",
+            "cuOpt does not support models with quadratic objectives and integer or semi-continuous variables",
         )
     end
 
+    ref_problem = Ref{cuOptOptimizationProblem}()
+    ret = cuOptCreateRangedProblem(
+        numrow,
+        numcol,
+        objective_sense,
+        objective_offset,
+        objective_coefficients,
+        constraint_matrix_row_offsets,
+        constraint_matrix_column_indices,
+        constraint_matrix_coefficients,
+        rowlower,
+        rowupper,
+        collower,
+        colupper,
+        var_type,
+        ref_problem,
+    )
+    _check_ret(ret, "cuOptCreateRangedProblem")
+
     if has_quadratic_objective
-        ref_problem = Ref{cuOptOptimizationProblem}()
-        ret = cuOptCreateQuadraticRangedProblem(
-            numrow,
-            numcol,
-            objective_sense,
-            objective_offset,
-            objective_coefficients,
-            qobj_row_offsets,
-            qobj_col_indices,
-            qobj_matrix_values,
-            constraint_matrix_row_offsets,
-            constraint_matrix_column_indices,
-            constraint_matrix_coefficients,
-            rowlower,
-            rowupper,
-            collower,
-            colupper,
-            ref_problem,
+        ret = cuOptSetQuadraticObjective(
+            ref_problem[],
+            Int32(length(qobj_values)),
+            qobj_rows,
+            qobj_cols,
+            qobj_values,
         )
-        _check_ret(ret, "cuOptCreateQuadraticRangedProblem")
-    else
-        ref_problem = Ref{cuOptOptimizationProblem}()
-        ret = cuOptCreateRangedProblem(
-            numrow,
-            numcol,
-            objective_sense,
-            objective_offset,
-            objective_coefficients,
-            constraint_matrix_row_offsets,
-            constraint_matrix_column_indices,
-            constraint_matrix_coefficients,
-            rowlower,
-            rowupper,
-            collower,
-            colupper,
-            var_type,
-            ref_problem,
-        )
-        _check_ret(ret, "cuOptCreateRangedProblem")
+        _check_ret(ret, "cuOptSetQuadraticObjective")
+    end
+
+    for S in (MOI.LessThan{Float64}, MOI.GreaterThan{Float64})
+        _add_quadratic_constraints(dest, src, mapping, ref_problem[], S)
     end
 
     dest.cuopt_problem = ref_problem[]

--- a/src/cuOpt.jl
+++ b/src/cuOpt.jl
@@ -46,7 +46,7 @@ function __init__()
         error("Failed to get cuOpt library version (status code: $status)")
     end
     version = VersionNumber(major[], minor[], patch[])
-    min, max = v"26.04", v"26.05"
+    min, max = v"26.06", v"26.07"
     if !(min <= version < max)
         error(
             "Incompatible cuOpt library version. Got $version, but supported versions are [$min, $max)",

--- a/src/gen/libcuopt.jl
+++ b/src/gen/libcuopt.jl
@@ -17,7 +17,7 @@
 #!format: off
 
 """
-A `[`cuOptOptimizationProblem`](@ref)` object contains a representation of an LP or MIP. It is created by `[`cuOptCreateProblem`](@ref)` or `[`cuOptCreateRangedProblem`](@ref)`. It is passed to `[`cuOptSolve`](@ref)`. It should be destroyed using `[`cuOptDestroyProblem`](@ref)`.
+A `[`cuOptOptimizationProblem`](@ref)` object contains a representation of an LP, MIP, QP, or QCQP. It is created by `[`cuOptCreateProblem`](@ref)`, `[`cuOptCreateRangedProblem`](@ref)`, or the quadratic create functions. Quadratic objectives and quadratic objectives and constraints may be set via `[`cuOptSetQuadraticObjective`](@ref)` and added via `[`cuOptAddQuadraticConstraint`](@ref)`. It is passed to `[`cuOptSolve`](@ref)` and destroyed with `[`cuOptDestroyProblem`](@ref)`.
 """
 const cuOptOptimizationProblem = Ptr{Cvoid}
 
@@ -41,7 +41,7 @@ The type of the integer number used by the solver. Use `[`cuOptGetIntSize`](@ref
 """
 const cuopt_int_t = Int32
 
-# no prototype is found for this function at cuopt_c.h:79:8, please use with caution
+# no prototype is found for this function at cuopt_c.h:82:8, please use with caution
 """
     cuOptGetFloatSize()
 
@@ -54,7 +54,7 @@ function cuOptGetFloatSize()
     ccall((:cuOptGetFloatSize, libcuopt), Int8, ())
 end
 
-# no prototype is found for this function at cuopt_c.h:84:8, please use with caution
+# no prototype is found for this function at cuopt_c.h:87:8, please use with caution
 """
     cuOptGetIntSize()
 
@@ -86,13 +86,15 @@ end
 """
     cuOptReadProblem(filename, problem_ptr)
 
-Read an optimization problem from an MPS file.
+Read an optimization problem from an MPS, QPS, or LP file.
+
+The file format is dispatched on the filename extension (case-insensitive): - ".lp", ".lp.gz", ".lp.bz2" → LP parser - ".mps", ".mps.gz", ".mps.bz2", ".qps", ".qps.gz", ".qps.bz2" → MPS parser - anything else (including no extension) is rejected.
 
 # Arguments
-* `filename`:\\[in\\] - The path to the MPS file.
-* `problem_ptr`:\\[out\\] - A pointer to a [`cuOptOptimizationProblem`](@ref). On output the problem will be created and initialized with the data from the MPS file
+* `filename`:\\[in\\] - The path to the MPS, QPS, or LP file. Must be a non-null, non-empty C string.
+* `problem_ptr`:\\[out\\] - A non-null pointer to a [`cuOptOptimizationProblem`](@ref). On output the problem will be created and initialized with the data from the input file.
 # Returns
-A status code indicating success or failure.
+A status code indicating success or failure. Returns [`CUOPT_INVALID_ARGUMENT`](@ref) if filename is null or empty, or if problem\\_ptr is null.
 """
 function cuOptReadProblem(filename, problem_ptr)
     ccall((:cuOptReadProblem, libcuopt), cuopt_int_t, (Ptr{Cchar}, Ptr{cuOptOptimizationProblem}), filename, problem_ptr)
@@ -139,7 +141,7 @@ Create an optimization problem of the form
 * `rhs`:\\[in\\] A pointer to an array of type [`cuopt_float_t`](@ref) of size num\\_constraints containing the right-hand side of the constraints
 * `lower_bounds`:\\[in\\] A pointer to an array of type [`cuopt_float_t`](@ref) of size num\\_variables containing the lower bounds of the variables
 * `upper_bounds`:\\[in\\] A pointer to an array of type [`cuopt_float_t`](@ref) of size num\\_variables containing the upper bounds of the variables
-* `variable_types`:\\[in\\] A pointer to an array of type char of size num\\_variables containing the types of the variables ([`CUOPT_CONTINUOUS`](@ref) or [`CUOPT_INTEGER`](@ref))
+* `variable_types`:\\[in\\] A pointer to an array of type char of size num\\_variables containing the types of the variables ([`CUOPT_CONTINUOUS`](@ref), [`CUOPT_INTEGER`](@ref), or [`CUOPT_SEMI_CONTINUOUS`](@ref))
 * `problem_ptr`:\\[out\\] Pointer to store the created optimization problem
 # Returns
 [`CUOPT_SUCCESS`](@ref) if successful, CUOPT\\_ERROR otherwise
@@ -173,7 +175,7 @@ Create an optimization problem of the form *
 * `constraint_upper_bounds`:\\[in\\] - A pointer to an array of type [`cuopt_float_t`](@ref) of size num\\_constraints containing the upper bounds of the constraints.
 * `variable_lower_bounds`:\\[in\\] - A pointer to an array of type [`cuopt_float_t`](@ref) of size num\\_variables containing the lower bounds of the variables.
 * `variable_upper_bounds`:\\[in\\] - A pointer to an array of type [`cuopt_float_t`](@ref) of size num\\_variables containing the upper bounds of the variables.
-* `variable_types`:\\[in\\] - A pointer to an array of type char of size num\\_variables containing the types of the variables ([`CUOPT_CONTINUOUS`](@ref) or [`CUOPT_INTEGER`](@ref)).
+* `variable_types`:\\[in\\] - A pointer to an array of type char of size num\\_variables containing the types of the variables ([`CUOPT_CONTINUOUS`](@ref), [`CUOPT_INTEGER`](@ref), or [`CUOPT_SEMI_CONTINUOUS`](@ref)).
 * `problem_ptr`:\\[out\\] - A pointer to a [`cuOptOptimizationProblem`](@ref). On output the problem will be created and initialized with the provided data.
 # Returns
 A status code indicating success or failure.
@@ -186,6 +188,10 @@ end
     cuOptCreateQuadraticProblem(num_constraints, num_variables, objective_sense, objective_offset, objective_coefficients, quadratic_objective_matrix_row_offsets, quadratic_objective_matrix_column_indices, quadratic_objective_matrix_coefficent_values, constraint_matrix_row_offsets, constraint_matrix_column_indices, constraint_matrix_coefficent_values, constraint_sense, rhs, lower_bounds, upper_bounds, problem_ptr)
 
 Create an optimization problem of the form
+
+!!! note
+
+    **Deprecated:** Use `[`cuOptCreateProblem`](@ref)` to set up the linear problem, then `[`cuOptSetQuadraticObjective`](@ref)` to specify the quadratic objective terms.
 
 ```c++
                 minimize/maximize  c^T x + x^T Q x + offset
@@ -222,6 +228,10 @@ end
 
 Create an optimization problem of the form *
 
+!!! note
+
+    **Deprecated:** Use `[`cuOptCreateRangedProblem`](@ref)` to set up the linear problem, then `[`cuOptSetQuadraticObjective`](@ref)` to specify the quadratic objective terms. For QCQP models, use `[`cuOptAddQuadraticConstraint`](@ref)` for each quadratic constraint.
+
 ```c++
                 minimize/maximize  c^T x + x^T Q x + offset
                   subject to       bl <= A*x <= bu
@@ -250,6 +260,51 @@ A status code indicating success or failure.
 """
 function cuOptCreateQuadraticRangedProblem(num_constraints, num_variables, objective_sense, objective_offset, objective_coefficients, quadratic_objective_matrix_row_offsets, quadratic_objective_matrix_column_indices, quadratic_objective_matrix_coefficent_values, constraint_matrix_row_offsets, constraint_matrix_column_indices, constraint_matrix_coefficients, constraint_lower_bounds, constraint_upper_bounds, variable_lower_bounds, variable_upper_bounds, problem_ptr)
     ccall((:cuOptCreateQuadraticRangedProblem, libcuopt), cuopt_int_t, (cuopt_int_t, cuopt_int_t, cuopt_int_t, cuopt_float_t, Ptr{cuopt_float_t}, Ptr{cuopt_int_t}, Ptr{cuopt_int_t}, Ptr{cuopt_float_t}, Ptr{cuopt_int_t}, Ptr{cuopt_int_t}, Ptr{cuopt_float_t}, Ptr{cuopt_float_t}, Ptr{cuopt_float_t}, Ptr{cuopt_float_t}, Ptr{cuopt_float_t}, Ptr{cuOptOptimizationProblem}), num_constraints, num_variables, objective_sense, objective_offset, objective_coefficients, quadratic_objective_matrix_row_offsets, quadratic_objective_matrix_column_indices, quadratic_objective_matrix_coefficent_values, constraint_matrix_row_offsets, constraint_matrix_column_indices, constraint_matrix_coefficients, constraint_lower_bounds, constraint_upper_bounds, variable_lower_bounds, variable_upper_bounds, problem_ptr)
+end
+
+"""
+    cuOptSetQuadraticObjective(problem, num_entries, row_index, col_index, coeff)
+
+Set the quadratic objective term x^T Q x on an existing problem.
+
+The matrix Q is specified in coordinate (triplet) format. This function may be called after `[`cuOptCreateProblem`](@ref)` or `[`cuOptCreateRangedProblem`](@ref)` to build a QP or QCQP model without using `[`cuOptCreateQuadraticProblem`](@ref)` or `[`cuOptCreateQuadraticRangedProblem`](@ref)`. Each call replaces any previously set quadratic objective. Duplicate (row, col) indices in the triplet arrays are summed.
+
+# Arguments
+* `problem`:\\[in\\] The optimization problem created by `[`cuOptCreateProblem`](@ref)` or `[`cuOptCreateRangedProblem`](@ref)`.
+* `num_entries`:\\[in\\] Number of non-zero entries in Q.
+* `row_index`:\\[in\\] Array of length num\\_entries with row indices (0-based).
+* `col_index`:\\[in\\] Array of length num\\_entries with column indices (0-based).
+* `coeff`:\\[in\\] Array of length num\\_entries with matrix coefficients.
+# Returns
+A status code indicating success or failure.
+"""
+function cuOptSetQuadraticObjective(problem, num_entries, row_index, col_index, coeff)
+    ccall((:cuOptSetQuadraticObjective, libcuopt), cuopt_int_t, (cuOptOptimizationProblem, cuopt_int_t, Ptr{cuopt_int_t}, Ptr{cuopt_int_t}, Ptr{cuopt_float_t}), problem, num_entries, row_index, col_index, coeff)
+end
+
+"""
+    cuOptAddQuadraticConstraint(problem, quad_num_entries, row_index, col_index, coeff, num_lin_entries, linear_index, linear_coeff, sense, rhs)
+
+Add a quadratic constraint x^T Q x + d^T x {<=, >=} rhs to an existing problem.
+
+The quadratic matrix Q is specified in coordinate (triplet) format. The linear term d is specified by parallel arrays of variable indices and coefficients. This function may be called after `[`cuOptCreateProblem`](@ref)` or `[`cuOptCreateRangedProblem`](@ref)` to build a QCQP model. Each call appends one quadratic constraint.
+
+# Arguments
+* `problem`:\\[in\\] The optimization problem created by `[`cuOptCreateProblem`](@ref)` or `[`cuOptCreateRangedProblem`](@ref)`.
+* `quad_num_entries`:\\[in\\] Number of non-zero entries in the quadratic part.
+* `row_index`:\\[in\\] Array of length quad\\_num\\_entries with row indices (0-based).
+* `col_index`:\\[in\\] Array of length quad\\_num\\_entries with column indices (0-based).
+* `coeff`:\\[in\\] Array of length quad\\_num\\_entries with quadratic matrix coefficients.
+* `num_lin_entries`:\\[in\\] Number of non-zero entries in the linear part.
+* `linear_index`:\\[in\\] Array of length num\\_lin\\_entries with variable indices (0-based).
+* `linear_coeff`:\\[in\\] Array of length num\\_lin\\_entries with linear coefficients.
+* `sense`:\\[in\\] Constraint sense: `[`CUOPT_LESS_THAN`](@ref)` ('L') for <= or `[`CUOPT_GREATER_THAN`](@ref)` ('G') for >=.
+* `rhs`:\\[in\\] Right-hand side of the constraint.
+# Returns
+A status code indicating success or failure.
+"""
+function cuOptAddQuadraticConstraint(problem, quad_num_entries, row_index, col_index, coeff, num_lin_entries, linear_index, linear_coeff, sense, rhs)
+    ccall((:cuOptAddQuadraticConstraint, libcuopt), cuopt_int_t, (cuOptOptimizationProblem, cuopt_int_t, Ptr{cuopt_int_t}, Ptr{cuopt_int_t}, Ptr{cuopt_float_t}, cuopt_int_t, Ptr{cuopt_int_t}, Ptr{cuopt_float_t}, Cchar, cuopt_float_t), problem, quad_num_entries, row_index, col_index, coeff, num_lin_entries, linear_index, linear_coeff, sense, rhs)
 end
 
 """
@@ -468,7 +523,7 @@ Get the variable types of an optimization problem.
 
 # Arguments
 * `problem`:\\[in\\] - The optimization problem.
-* `variable_types_ptr`:\\[out\\] - A pointer to an array of type char of size num\\_variables that on output will contain the types of the variables ([`CUOPT_CONTINUOUS`](@ref) or [`CUOPT_INTEGER`](@ref)).
+* `variable_types_ptr`:\\[out\\] - A pointer to an array of type char of size num\\_variables that on output will contain the types of the variables ([`CUOPT_CONTINUOUS`](@ref), [`CUOPT_INTEGER`](@ref), or [`CUOPT_SEMI_CONTINUOUS`](@ref)).
 # Returns
 A status code indicating success or failure.
 """
@@ -954,6 +1009,8 @@ const CUOPT_TIME_LIMIT = "time_limit"
 
 const CUOPT_WORK_LIMIT = "work_limit"
 
+const CUOPT_NODE_LIMIT = "node_limit"
+
 const CUOPT_PDLP_SOLVER_MODE = "pdlp_solver_mode"
 
 const CUOPT_METHOD = "method"
@@ -980,11 +1037,17 @@ const CUOPT_ORDERING = "ordering"
 
 const CUOPT_BARRIER_DUAL_INITIAL_POINT = "barrier_dual_initial_point"
 
+const CUOPT_BARRIER_ITERATIVE_REFINEMENT = "barrier_iterative_refinement"
+
+const CUOPT_BARRIER_STEP_SCALE = "barrier_step_scale"
+
 const CUOPT_ELIMINATE_DENSE_COLUMNS = "eliminate_dense_columns"
 
 const CUOPT_CUDSS_DETERMINISTIC = "cudss_deterministic"
 
 const CUOPT_PRESOLVE = "presolve"
+
+const CUOPT_MIP_PROBING = "mip_probing"
 
 const CUOPT_DUAL_POSTSOLVE = "dual_postsolve"
 
@@ -1006,6 +1069,8 @@ const CUOPT_MIP_SCALING = "mip_scaling"
 
 const CUOPT_MIP_PRESOLVE = "mip_presolve"
 
+const CUOPT_MIP_SYMMETRY = "mip_symmetry"
+
 const CUOPT_MIP_RELIABILITY_BRANCHING = "mip_reliability_branching"
 
 const CUOPT_MIP_CUT_PASSES = "mip_cut_passes"
@@ -1016,6 +1081,8 @@ const CUOPT_MIP_MIXED_INTEGER_GOMORY_CUTS = "mip_mixed_integer_gomory_cuts"
 
 const CUOPT_MIP_KNAPSACK_CUTS = "mip_knapsack_cuts"
 
+const CUOPT_MIP_FLOW_COVER_CUTS = "mip_flow_cover_cuts"
+
 const CUOPT_MIP_IMPLIED_BOUND_CUTS = "mip_implied_bound_cuts"
 
 const CUOPT_MIP_CLIQUE_CUTS = "mip_clique_cuts"
@@ -1023,6 +1090,8 @@ const CUOPT_MIP_CLIQUE_CUTS = "mip_clique_cuts"
 const CUOPT_MIP_STRONG_CHVATAL_GOMORY_CUTS = "mip_strong_chvatal_gomory_cuts"
 
 const CUOPT_MIP_REDUCED_COST_STRENGTHENING = "mip_reduced_cost_strengthening"
+
+const CUOPT_MIP_OBJECTIVE_STEP = "mip_objective_step"
 
 const CUOPT_MIP_CUT_CHANGE_THRESHOLD = "mip_cut_change_threshold"
 
@@ -1047,6 +1116,8 @@ const CUOPT_PRESOLVE_FILE = "presolve_file"
 const CUOPT_RANDOM_SEED = "random_seed"
 
 const CUOPT_PDLP_PRECISION = "pdlp_precision"
+
+const CUOPT_MIP_SEMICONTINUOUS_BIG_M = "mip_semi_continuous_big_m"
 
 const CUOPT_MIP_HYPER_HEURISTIC_POPULATION_SIZE = "mip_hyper_heuristic_population_size"
 
@@ -1110,8 +1181,6 @@ const CUOPT_TERMINATION_STATUS_WORK_LIMIT = 10
 
 const CUOPT_TERMINATION_STATUS_UNBOUNDED_OR_INFEASIBLE = 11
 
-const CUOPT_TERIMINATION_STATUS_WORK_LIMIT = 10
-
 const CUOPT_MINIMIZE = 1
 
 const CUOPT_MAXIMIZE = -1
@@ -1125,6 +1194,8 @@ const CUOPT_EQUAL = Cchar('E')
 const CUOPT_CONTINUOUS = Cchar('C')
 
 const CUOPT_INTEGER = Cchar('I')
+
+const CUOPT_SEMI_CONTINUOUS = Cchar('S')
 
 const CUOPT_INFINITY = INFINITY
 
@@ -1185,3 +1256,7 @@ const CUOPT_MIP_SCALING_OFF = 0
 const CUOPT_MIP_SCALING_ON = 1
 
 const CUOPT_MIP_SCALING_NO_OBJECTIVE = 2
+
+const CUOPT_BARRIER_ITERATIVE_REFINEMENT_OFF = 0
+
+const CUOPT_BARRIER_ITERATIVE_REFINEMENT_ON = 1

--- a/test/C_wrapper.jl
+++ b/test/C_wrapper.jl
@@ -107,16 +107,19 @@ function test_Direct_C_call()
     return
 end
 
-function test_QuadraticProblem_C_call()
+# minimize x² + y² s.t. x + y ≥ 1, 0 ≤ x,y ≤ 10. Optimum at x = y = 0.5, obj = 0.5.
+function test_QuadraticObjective_C_call()
     n_col = Cint(2)
     n_row = Cint(1)
 
     colcost = Cdouble[0.0, 0.0]
     collower = Cdouble[0.0, 0.0]
     colupper = Cdouble[10.0, 10.0]
+    coltype = Cchar[cuOpt.CUOPT_CONTINUOUS, cuOpt.CUOPT_CONTINUOUS]
 
-    q_row_offsets = Cint[0, 1, 2]
-    q_col_indices = Cint[0, 1]
+    # Q = diag(1, 1) in triplet (COO) form
+    q_rows = Cint[0, 1]
+    q_cols = Cint[0, 1]
     q_values = Cdouble[1.0, 1.0]
 
     a_row_offsets = Cint[0, 2]
@@ -129,15 +132,12 @@ function test_QuadraticProblem_C_call()
     objective_sense = Int32(cuOpt.CUOPT_MINIMIZE)
     problem_ref = Ref{cuOpt.cuOptOptimizationProblem}()
 
-    ret = cuOpt.cuOptCreateQuadraticProblem(
+    ret = cuOpt.cuOptCreateProblem(
         n_row,
         n_col,
         objective_sense,
         0.0,
         colcost,
-        q_row_offsets,
-        q_col_indices,
-        q_values,
         a_row_offsets,
         a_col_indices,
         a_values,
@@ -145,10 +145,20 @@ function test_QuadraticProblem_C_call()
         rhs,
         collower,
         colupper,
+        coltype,
         problem_ref,
     )
     @test ret == 0
     problem = problem_ref[]
+
+    ret = cuOpt.cuOptSetQuadraticObjective(
+        problem,
+        Cint(length(q_values)),
+        q_rows,
+        q_cols,
+        q_values,
+    )
+    @test ret == 0
 
     settings_ref = Ref{cuOpt.cuOptSolverSettings}()
     ret = cuOpt.cuOptCreateSolverSettings(settings_ref)
@@ -176,16 +186,18 @@ function test_QuadraticProblem_C_call()
     return
 end
 
-function test_QuadraticRangedProblem_C_call()
+# Same QP as above expressed with a ranged constraint 1 ≤ x + y ≤ 10.
+function test_QuadraticObjective_Ranged_C_call()
     n_col = Cint(2)
     n_row = Cint(1)
 
     colcost = Cdouble[0.0, 0.0]
     collower = Cdouble[0.0, 0.0]
     colupper = Cdouble[10.0, 10.0]
+    coltype = Cchar[cuOpt.CUOPT_CONTINUOUS, cuOpt.CUOPT_CONTINUOUS]
 
-    q_row_offsets = Cint[0, 1, 2]
-    q_col_indices = Cint[0, 1]
+    q_rows = Cint[0, 1]
+    q_cols = Cint[0, 1]
     q_values = Cdouble[1.0, 1.0]
 
     a_row_offsets = Cint[0, 2]
@@ -198,15 +210,12 @@ function test_QuadraticRangedProblem_C_call()
     objective_sense = Int32(cuOpt.CUOPT_MINIMIZE)
     problem_ref = Ref{cuOpt.cuOptOptimizationProblem}()
 
-    ret = cuOpt.cuOptCreateQuadraticRangedProblem(
+    ret = cuOpt.cuOptCreateRangedProblem(
         n_row,
         n_col,
         objective_sense,
         0.0,
         colcost,
-        q_row_offsets,
-        q_col_indices,
-        q_values,
         a_row_offsets,
         a_col_indices,
         a_values,
@@ -214,10 +223,20 @@ function test_QuadraticRangedProblem_C_call()
         constraint_upper,
         collower,
         colupper,
+        coltype,
         problem_ref,
     )
     @test ret == 0
     problem = problem_ref[]
+
+    ret = cuOpt.cuOptSetQuadraticObjective(
+        problem,
+        Cint(length(q_values)),
+        q_rows,
+        q_cols,
+        q_values,
+    )
+    @test ret == 0
 
     settings_ref = Ref{cuOpt.cuOptSolverSettings}()
     ret = cuOpt.cuOptCreateSolverSettings(settings_ref)

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -55,7 +55,9 @@ function test_runtests_cache_optimizer()
                 MOI.ConstraintBasisStatus,
             ],
         );
-        exclude = [],
+        # cuOpt's QP solver assumes convexity, so nonconvex QCQP problems are
+        # out of scope.
+        exclude = ["test_quadratic_nonconvex_constraint_integration"],
     )
     return
 end
@@ -70,6 +72,54 @@ function test_air05()
     MOI.optimize!(model)
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.OPTIMAL
     @test isapprox(MOI.get(model, MOI.ObjectiveValue()), 26374.0; rtol = 1e-4)
+    return
+end
+
+# Exercise the SOC and RSOC conic conformance tests through MOI's bridge layer.
+# With with_bridge_type, MOI.Bridges.full_bridge_optimizer picks up the
+# SOCtoNonConvexQuadBridge / RSOCtoNonConvexQuadBridge bridges that the
+# wrapper declares via ListOfNonstandardBridges. Both cones lower to
+# ScalarQuadraticFunction-in-LessThan (plus an explicit t >= 0 row from the
+# bridge) before reaching cuOpt, which detects the SOC structure in the
+# quadratic form.
+function test_runtests_bridge_optimizer()
+    model = MOI.instantiate(
+        cuOpt.Optimizer;
+        with_cache_type = Float64,
+        with_bridge_type = Float64,
+    )
+    MOI.Test.runtests(
+        model,
+        MOI.Test.Config(;
+            atol = 1e-3,
+            rtol = 1e-3,
+            exclude = Any[
+                MOI.DualObjectiveValue,
+                MOI.ConstraintPrimal,
+                MOI.ConstraintDual,
+                MOI.ConstraintBasisStatus,
+            ],
+        );
+        # cuOpt's QP solver assumes convexity, so nonconvex QCQP problems are
+        # out of scope.
+        # Known cuOpt limitation: the barrier QCQP solver does not certify
+        # primal-infeasibility or dual-infeasibility (unboundedness). It
+        # returns INFEASIBLE_OR_UNBOUNDED (or NUMERICAL_ERROR in degenerate
+        # cases) where MOI tests assert INFEASIBLE / DUAL_INFEASIBLE.
+        # The following tests exercise this discrimination and stay excluded
+        # until the cuOpt-side issue is resolved.
+        exclude = [
+            "test_quadratic_nonconvex_constraint_integration",
+            r"^test_conic_RotatedSecondOrderCone_INFEASIBLE$",
+            "test_conic_SecondOrderCone_no_initial_bound",
+            "test_conic_SecondOrderCone_negative_post_bound_2",
+            "test_conic_SecondOrderCone_negative_post_bound_3",
+        ],
+        include = [
+            "test_conic_SecondOrderCone",
+            "test_conic_RotatedSecondOrderCone",
+        ],
+    )
     return
 end
 


### PR DESCRIPTION
1. Updates to 26.06 and drops older versions
2. Replace use of deprecated constructors for QPs
3. Quadratic constraint and SOC support
4. Semicontinuous variable support
5. Support for NodeLimit parameter
 
Confirmed additional MOI tests that are now passing:
```
test_quadratic_constraint_GreaterThan
test_quadratic_constraint_LessThan
test_quadratic_constraint_basic
test_quadratic_constraint_minimize
test_conic_SecondOrderCone_VectorAffineFunction
test_basic_VariableIndex_Semicontinuous
test_linear_Semicontinuous_integration
```