### PR TITLE
test: exclude test_conic_SecondOrderCone_negative_initial_bound

### DIFF
--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -108,10 +108,17 @@ function test_runtests_bridge_optimizer()
         # cases) where MOI tests assert INFEASIBLE / DUAL_INFEASIBLE.
         # The following tests exercise this discrimination and stay excluded
         # until the cuOpt-side issue is resolved.
+        #
+        # The four SOC tests below all call MOI.delete on a bridged SOC
+        # constraint. The SOCtoNonConvexQuadBridge cleanup triggers
+        # call_in_context in MOI's variable bridge map, which crashes Julia's
+        # JIT compiler (SIGSEGV in jl_type_infer) on Julia 1.12.x. Tracked
+        # in https://github.com/NVIDIA/cuopt/issues/1485.
         exclude = [
             "test_quadratic_nonconvex_constraint_integration",
             r"^test_conic_RotatedSecondOrderCone_INFEASIBLE$",
             "test_conic_SecondOrderCone_no_initial_bound",
+            "test_conic_SecondOrderCone_negative_initial_bound",
             "test_conic_SecondOrderCone_negative_post_bound_2",
             "test_conic_SecondOrderCone_negative_post_bound_3",
         ],


### PR DESCRIPTION
## Summary

`test_conic_SecondOrderCone_negative_initial_bound` crashes Julia 1.12.x's JIT compiler (SIGSEGV in `jl_type_infer`) and needs to be added to the same exclude list as the other three `MOI.delete`-after-SOC tests that are already excluded.

## Root cause

`SOCtoNonConvexQuadBridge` was added in 26.06. When `MOI.delete` is called on a bridged `VectorOfVariables in SecondOrderCone` constraint, the bridge cleanup (`bridge.quad` + `bridge.var_pos`) triggers `call_in_context` in MOI's variable bridge map. The deeply nested dispatch chain crashes Julia 1.12.x's type inferencer during JIT compilation.

Crash stack:
```
test_conic_SecondOrderCone_negative_initial_bound
  → bridge_optimizer.jl:765 (delete)
  → Variable/map.jl:652 (call_in_context)
  → jl_type_infer  ← SIGSEGV
```

The same crash affects the three tests already excluded:
- `test_conic_SecondOrderCone_no_initial_bound`
- `test_conic_SecondOrderCone_negative_post_bound_2`
- `test_conic_SecondOrderCone_negative_post_bound_3`

This test was simply missed when SOC support was introduced.

Tracking: https://github.com/NVIDIA/cuopt/issues/1485

🤖 Generated with [Claude Code](https://claude.com/claude-code)